### PR TITLE
swap beach and mountain accent colors and darken aqua to pass WCAG AA

### DIFF
--- a/components/TripCard/TripCard.module.scss
+++ b/components/TripCard/TripCard.module.scss
@@ -47,7 +47,7 @@
     padding: 6px 12px;
 
     &.beach {
-      background-color: var(--aqua-accent-darker);
+      background-color: var(--violet-accent-darker);
     }
 
     &.lifestyle {
@@ -59,7 +59,7 @@
     }
 
     &.mountain {
-      background-color: var(--violet-accent-darker);
+      background-color: var(--aqua-accent-darker);
     }
   }
 }

--- a/styles/base/_colors.scss
+++ b/styles/base/_colors.scss
@@ -24,6 +24,6 @@
   // darkened accent colors until passing WCAG AA https://webaim.org/resources/contrastchecker/
   --violet-accent-darker: #6266E4;
   --lavender-accent-darker: #3E6CEA;
-  --aqua-accent-darker: #398484;
+  --aqua-accent-darker: #378181;
   --pink-accent-darker: #C000F5;
 }


### PR DESCRIPTION
# Purpose
Swap beach and mountain accent colors and darken `var(--aqua-accent)` to pass WCAG AA

![image](https://user-images.githubusercontent.com/17103622/168498491-ed35605a-2f35-48af-9279-1df1f0569176.png)
